### PR TITLE
FOUN-388: transform/v2_2: explicit None check to allow cmd and entrypoint overr…

### DIFF
--- a/transform/v2_2/metadata_.py
+++ b/transform/v2_2/metadata_.py
@@ -156,9 +156,9 @@ def Override(data,
   output['config'] = defaults.get('config', {})
 
   # pytype: disable=attribute-error
-  if options.entrypoint:
+  if options.entrypoint is not None:
     output['config']['Entrypoint'] = options.entrypoint
-  if options.cmd:
+  if options.cmd is not None:
     output['config']['Cmd'] = options.cmd
   if options.user:
     output['config']['User'] = options.user


### PR DESCRIPTION
…ide to empty

This allows overriding `CMD` and `ENTRYPOINT` to be empty. This was not possible before, since empty lists are "falsy" in python, and that's exactly what we need to set these values to in order to override them to be empty.